### PR TITLE
Inline versions in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,33 +1,18 @@
-[versions]
-agp = "8.11.0"
-kotlin = "2.2.0"
-googleServices = "4.4.3"
-crashlyticsGradle = "3.0.4"
-coreKtx = "1.16.0"
-appcompat = "1.7.1"
-material = "1.12.0"
-playServicesMaps = "19.2.0"
-gson = "2.13.1"
-okhttp = "4.12.0"
-firebaseBom = "33.16.0"
-playServicesAds = "25.2.0"
-reviewKtx = "2.0.2"
-
 [libraries]
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
-firebase-analytics-ktx = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "playServicesAds" }
-play-review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "reviewKtx" }
+androidx-core-ktx = "androidx.core:core-ktx:1.16.0"
+androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
+material = "com.google.android.material:material:1.12.0"
+play-services-maps = "com.google.android.gms:play-services-maps:19.2.0"
+gson = "com.google.code.gson:gson:2.13.1"
+okhttp = "com.squareup.okhttp3:okhttp:4.12.0"
+firebase-bom = "com.google.firebase:firebase-bom:33.16.0"
+firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+play-services-ads = "com.google.android.gms:play-services-ads:25.2.0"
+play-review-ktx = "com.google.android.play:review-ktx:2.0.2"
 
 [plugins]
-android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsGradle" }
+android-application = { id = "com.android.application", version = "8.11.0" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.2.0" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.3" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.4" }


### PR DESCRIPTION
## Summary
Drop the \`[versions]\` section. Each library and plugin entry now carries its version inline (string shorthand for libraries, \`version = "…"\` for plugins). Every version was referenced exactly once, so the indirection just added noise.

## Test plan
- [ ] CI build (\`assembleRegularDebug\`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)