### PR TITLE
Migrate from firebase-analytics-ktx to firebase-analytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.okhttp)
     "googleImplementation"(platform(libs.firebase.bom))
-    "googleImplementation"(libs.firebase.analytics.ktx)
+    "googleImplementation"(libs.firebase.analytics)
     "googleImplementation"(libs.firebase.crashlytics)
     "googleImplementation"(libs.play.services.ads)
     "googleImplementation"(libs.play.review.ktx)

--- a/app/src/google/java/com/tananaev/celltowerradar/GoogleActivity.kt
+++ b/app/src/google/java/com/tananaev/celltowerradar/GoogleActivity.kt
@@ -11,9 +11,9 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
 import com.google.android.play.core.review.ReviewManagerFactory
+import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
 
 class GoogleActivity : AppCompatActivity() {
     private lateinit var firebaseAnalytics: FirebaseAnalytics

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ play-services-maps = "com.google.android.gms:play-services-maps:19.2.0"
 gson = "com.google.code.gson:gson:2.13.1"
 okhttp = "com.squareup.okhttp3:okhttp:4.12.0"
 firebase-bom = "com.google.firebase:firebase-bom:33.16.0"
-firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 play-services-ads = "com.google.android.gms:play-services-ads:25.2.0"
 play-review-ktx = "com.google.android.play:review-ktx:2.0.2"


### PR DESCRIPTION
## Summary
- Rename the \`firebase-analytics-ktx\` alias to \`firebase-analytics\` in the version catalog and update the dependency reference in \`app/build.gradle.kts\`
- Move the Kotlin imports from the removed \`com.google.firebase.ktx\` and \`com.google.firebase.analytics.ktx\` packages to their new top-level locations (\`com.google.firebase\` and \`com.google.firebase.analytics\`)

The \`-ktx\` Firebase artifacts were consolidated into the main artifacts in BOM 33.x and removed entirely in BOM 34.0.0. The current pin (33.16.0) still resolves the stub, but this avoids a hard break when the BOM is bumped.

## Test plan
- [ ] \`./gradlew :app:assembleGoogleRelease\` succeeds
- [ ] After a future BOM bump to 34.x, build still resolves Firebase Analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)