### PR TITLE
Migrate to compilerOptions DSL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -30,9 +32,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the deprecated \`android { kotlinOptions { ... } }\` block with the top-level \`kotlin { compilerOptions { ... } }\` DSL
- Use the typed \`JvmTarget.JVM_17\` enum value instead of stringified \`JavaVersion.VERSION_17.toString()\`
- Adds the \`org.jetbrains.kotlin.gradle.dsl.JvmTarget\` import

## Test plan
- [ ] \`./gradlew :app:assembleRegularRelease :app:assembleGoogleRelease\` succeeds
- [ ] No \`'fun BaseAppModuleExtension.kotlinOptions(...)' is deprecated\` warning during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)